### PR TITLE
Add trend charts to dashboard pages

### DIFF
--- a/app/dashboard/expenses/expenses-client.tsx
+++ b/app/dashboard/expenses/expenses-client.tsx
@@ -14,11 +14,20 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { TrendChart } from '@/components/charts/TrendChart';
 
 export function ExpensesClient() {
   const [expenses, setExpenses] = useState<Expense[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  const chartData = expenses
+    .slice()
+    .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+    .map((expense) => ({
+      date: new Date(expense.createdAt).toLocaleDateString(),
+      value: expense.amount,
+    }));
 
   const restaurantId = 'clxne1o4w00007867z1f896l9';
 
@@ -69,6 +78,9 @@ export function ExpensesClient() {
 
   return (
     <div className="grid gap-8 md:grid-cols-3">
+      <div className="md:col-span-3">
+        <TrendChart data={chartData} title="Expenses Over Time" />
+      </div>
       <div className="md:col-span-2">
         <Card>
           <CardHeader>

--- a/app/dashboard/inventory/inventory-client.tsx
+++ b/app/dashboard/inventory/inventory-client.tsx
@@ -14,11 +14,20 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { TrendChart } from '@/components/charts/TrendChart';
 
 export function InventoryClient() {
   const [items, setItems] = useState<InventoryItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  const chartData = items
+    .slice()
+    .sort((a, b) => new Date(a.purchasedAt).getTime() - new Date(b.purchasedAt).getTime())
+    .map((item) => ({
+      date: new Date(item.purchasedAt).toLocaleDateString(),
+      value: item.totalCost,
+    }));
 
   // Dummy restaurantId. In a real multi-tenant app, this would come from auth/context.
   const restaurantId = 'clxne1o4w00007867z1f896l9'; // Replace with a real ID from your DB
@@ -82,6 +91,9 @@ export function InventoryClient() {
 
   return (
     <div className="grid gap-8 md:grid-cols-3">
+      <div className="md:col-span-3">
+        <TrendChart data={chartData} title="Inventory Purchases Over Time" />
+      </div>
       <div className="md:col-span-2">
         <Card>
           <CardHeader>

--- a/app/dashboard/labor/labor-client.tsx
+++ b/app/dashboard/labor/labor-client.tsx
@@ -14,11 +14,20 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { TrendChart } from '@/components/charts/TrendChart';
 
 export function LaborClient() {
   const [entries, setEntries] = useState<LaborEntry[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  const chartData = entries
+    .slice()
+    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+    .map((entry) => ({
+      date: new Date(entry.date).toLocaleDateString(),
+      value: entry.totalWages,
+    }));
 
   // Dummy restaurantId
   const restaurantId = 'clxne1o4w00007867z1f896l9';
@@ -99,6 +108,9 @@ export function LaborClient() {
 
   return (
     <div className="grid gap-8 md:grid-cols-3">
+      <div className="md:col-span-3">
+        <TrendChart data={chartData} title="Labor Cost Over Time" />
+      </div>
       <div className="md:col-span-2">
         <Card>
           <CardHeader>

--- a/app/dashboard/loans/loans-client.tsx
+++ b/app/dashboard/loans/loans-client.tsx
@@ -14,11 +14,20 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { TrendChart } from '@/components/charts/TrendChart';
 
 export function LoansClient() {
   const [loans, setLoans] = useState<Loan[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  const chartData = loans
+    .slice()
+    .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+    .map((loan) => ({
+      date: new Date(loan.createdAt).toLocaleDateString(),
+      value: loan.balance,
+    }));
 
   const restaurantId = 'clxne1o4w00007867z1f896l9';
 
@@ -71,6 +80,9 @@ export function LoansClient() {
 
   return (
     <div className="grid gap-8 md:grid-cols-3">
+      <div className="md:col-span-3">
+        <TrendChart data={chartData} title="Loan Balances Over Time" />
+      </div>
       <div className="md:col-span-2">
         <Card>
           <CardHeader>

--- a/app/dashboard/sales/sales-client.tsx
+++ b/app/dashboard/sales/sales-client.tsx
@@ -14,11 +14,20 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { TrendChart } from '@/components/charts/TrendChart';
 
 export function SalesClient() {
   const [entries, setEntries] = useState<SaleEntry[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  const chartData = entries
+    .slice()
+    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+    .map((entry) => ({
+      date: new Date(entry.date).toLocaleDateString(),
+      value: entry.netSales,
+    }));
 
   // Dummy restaurantId
   const restaurantId = 'clxne1o4w00007867z1f896l9';
@@ -80,6 +89,9 @@ export function SalesClient() {
 
   return (
     <div className="grid gap-8 md:grid-cols-3">
+      <div className="md:col-span-3">
+        <TrendChart data={chartData} title="Net Sales Over Time" />
+      </div>
       <div className="md:col-span-2">
         <Card>
           <CardHeader>

--- a/components/charts/TrendChart.tsx
+++ b/components/charts/TrendChart.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+
+interface TrendChartProps {
+  data: { date: string; value: number }[];
+  title: string;
+}
+
+export function TrendChart({ data, title }: TrendChartProps) {
+  const sorted = [...data].sort(
+    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="h-[300px]">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={sorted} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="date" />
+              <YAxis />
+              <Tooltip formatter={(value) => [`$${Number(value).toFixed(2)}`, 'Amount']} />
+              <Line type="monotone" dataKey="value" stroke="#8884d8" strokeWidth={2} dot={false} />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable `TrendChart` component for time-based analytics
- show trend charts in Sales, Inventory, Labor, Expenses, and Loans pages

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68655514c9208323ac1a6f8cc33d8382