### PR TITLE
Fix data parsing for inventory, recipes and expenses pages

### DIFF
--- a/app/dashboard/expenses/expenses-client.tsx
+++ b/app/dashboard/expenses/expenses-client.tsx
@@ -37,7 +37,8 @@ export function ExpensesClient() {
       const response = await fetch(`/api/expenses?restaurantId=${restaurantId}`);
       if (!response.ok) throw new Error('Failed to fetch expenses');
       const data = await response.json();
-      setExpenses(data);
+      // Support both plain array and { data: [] } responses
+      setExpenses(Array.isArray(data) ? data : data.data ?? []);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An unknown error occurred');
     } finally {

--- a/app/dashboard/inventory/inventory-client.tsx
+++ b/app/dashboard/inventory/inventory-client.tsx
@@ -40,7 +40,8 @@ export function InventoryClient() {
         throw new Error('Failed to fetch inventory');
       }
       const data = await response.json();
-      setItems(data);
+      // Support both plain array and { data: [] } responses
+      setItems(Array.isArray(data) ? data : data.data ?? []);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An unknown error occurred');
     } finally {

--- a/app/dashboard/recipes/recipes-client.tsx
+++ b/app/dashboard/recipes/recipes-client.tsx
@@ -45,9 +45,10 @@ export function RecipesClient() {
       
       const recipesData = await recipesRes.json();
       const inventoryData = await inventoryRes.json();
-      
-      setRecipes(recipesData);
-      setInventory(inventoryData);
+
+      // Support both plain array and { data: [] } responses
+      setRecipes(Array.isArray(recipesData) ? recipesData : recipesData.data ?? []);
+      setInventory(Array.isArray(inventoryData) ? inventoryData : inventoryData.data ?? []);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An unknown error occurred');
     } finally {


### PR DESCRIPTION
## Summary
- handle API responses wrapped in `{ data }` for inventory, recipes and expenses pages

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: cannot fetch binaries.prisma.sh)*

------
https://chatgpt.com/codex/tasks/task_e_68655d9e5788832384e123a7d5602337